### PR TITLE
Fix file path issue with `check_dead_strains`

### DIFF
--- a/R/check-dead-strains.R
+++ b/R/check-dead-strains.R
@@ -14,7 +14,7 @@ check_dead_strains <- function(dir, death_thresh = 10) {
   assertthat::assert_that(assertthat::is.writeable(dir))
   assertthat::assert_that(assertthat::is.number(death_thresh))
 
-  bio_replicate_file <- read_csv(dir, 'biological-replicate-annotation.csv')
+  bio_replicate_file <- read_csv(file.path(dir, 'biological-replicate-annotation.csv'))
 
 
   sm_data <- screenmill::read_screenmill(dir) %>%


### PR DESCRIPTION
`read_csv` was mistakenly passed the directory path and the file name as separate arguments. They should be combined into one string with e.g. `paste0` or preferably `file.path`.